### PR TITLE
Provide the binding with a minor mode to be more consistent with other packages

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,10 +12,10 @@ packages.el:
 config.el:
 #+begin_src emacs-lisp
 (use-package! org-edit-indirect
-  :after org)
+  :hook (org-mode . org-edit-indirect-mode))
 #+end_src
 
 ***** Usage
 
 - Move cursor to any source, verse, comment, quote block; or a paragraph, headline, property drawer, or a plain list
-- ~<C-c '>~ (unless you've changed the default keybinding to ~org-edit-special~)
+- ~<C-c '>~ (or whatever ~org-edit-special~ is normally bound to)

--- a/org-edit-indirect.el
+++ b/org-edit-indirect.el
@@ -25,6 +25,7 @@
 (require 'org-element)
 
 (defun org-edit-indirect-generic-block (org-element)
+  "Edit ORG-ELEMENT with `edit-indirect-region'."
   (interactive)
   (let* ((el-type (org-element-type (org-element-context org-element)))
          (parent (org-element-property :parent org-element))
@@ -39,9 +40,12 @@
     (edit-indirect-region beg end :display)))
 
 (defun org-edit-indirect-special+ (&optional arg)
-  "Call a special editor fore the element at point.
-This fn extends `org-edit-special', allowing to edit blocks that
-the original function doesn't let you."
+  "Call a special editor for the element at point.
+
+This extends `org-edit-special' to edit blocks that it doesn't
+support.
+
+ARG is passed to `org-edit-special'."
   (interactive "P")
   (let* ((element (org-element-at-point))
          (context (org-element-context element)))
@@ -53,8 +57,14 @@ the original function doesn't let you."
       (_ (org-edit-special arg)))))
 
 (defun org-edit-indirect--before-commit ()
-  ;; if not done this way, edit-indirect chews up the EOF and #+end_quote ends
-  ;; up appended to the previous line, breaking the structure of the block
+  "Prevent edit-indirect from chewing up EOF.
+
+Without this, edit-indirect would chew up the EOF, causing
+#+end_quote to be appended to the previous line, breaking the
+structure of the block.
+
+This is added to `edit-indirect-before-commit-hook' by
+`org-edit-indirect-mode'."
   (when (edit-indirect-buffer-indirect-p)
     (goto-char (point-max))
     (forward-char -1)

--- a/org-edit-indirect.el
+++ b/org-edit-indirect.el
@@ -88,6 +88,9 @@ This is added to `edit-indirect-before-commit-hook' by
     (remove-hook 'edit-indirect-before-commit-hook #'org-edit-indirect--before-commit t)
     (remove-hook 'edit-indirect-after-creation-hook #'outline-show-all t)))
 
+;; Accommodate existing users before the minor mode refactor
+(add-hook 'org-mode-hook #'org-edit-indirect-mode)
+
 (provide 'org-edit-indirect)
 
 ;;; org-edit-indirect.el ends here

--- a/org-edit-indirect.el
+++ b/org-edit-indirect.el
@@ -62,10 +62,21 @@ the original function doesn't let you."
       (goto-char (point-max))
       (newline))))
 
-(add-hook 'edit-indirect-before-commit-hook #'org-edit-indirect--before-commit)
-(add-hook 'edit-indirect-after-creation-hook #'outline-show-all)
-
-(define-key org-mode-map [remap org-edit-special] #'org-edit-indirect-special+)
+;;;###autoload
+(define-minor-mode org-edit-indirect-mode
+  "Edit any Org block with \\<org-mode-map>\\[org-edit-special]."
+  :global nil
+  :lighter ""
+  :keymap (let ((map (make-sparse-keymap)))
+            (define-key map
+              [remap org-edit-special] #'org-edit-indirect-special+)
+            map)
+  (if org-edit-indirect-mode
+      (progn
+        (add-hook 'edit-indirect-before-commit-hook #'org-edit-indirect--before-commit nil t)
+        (add-hook 'edit-indirect-after-creation-hook #'outline-show-all nil t))
+    (remove-hook 'edit-indirect-before-commit-hook #'org-edit-indirect--before-commit t)
+    (remove-hook 'edit-indirect-after-creation-hook #'outline-show-all t)))
 
 (provide 'org-edit-indirect)
 

--- a/org-edit-indirect.el
+++ b/org-edit-indirect.el
@@ -49,18 +49,18 @@ the original function doesn't let you."
       ((or `quote-block `verse-block `comment-block
            `paragraph `headline `property-drawer
            `plain-list `item)
-          (org-edit-indirect-generic-block element))
+       (org-edit-indirect-generic-block element))
       (_ (org-edit-special arg)))))
 
 (defun org-edit-indirect--before-commit ()
   ;; if not done this way, edit-indirect chews up the EOF and #+end_quote ends
   ;; up appended to the previous line, breaking the structure of the block
   (when (edit-indirect-buffer-indirect-p)
-   (goto-char (point-max))
-   (forward-char -1)
-   (when (not (looking-at "$"))
-     (goto-char (point-max))
-     (newline))))
+    (goto-char (point-max))
+    (forward-char -1)
+    (when (not (looking-at "$"))
+      (goto-char (point-max))
+      (newline))))
 
 (add-hook 'edit-indirect-before-commit-hook #'org-edit-indirect--before-commit)
 (add-hook 'edit-indirect-after-creation-hook #'outline-show-all)


### PR DESCRIPTION
Usually packages are not supposed to create keybinds on load. By moving the keybind and the hooks into a minor mode, this PR allows the user to reverse the changes if they want to.

By using a local minor mode, this also avoids changing the behavior of `edit-indirect` outside of Org --- the hooks are now added locally.

This PR also adds docstrings to all functions.

---

This requires a change in the set up code though:

```elisp
(use-package! org-edit-indirect
  :hook (org-mode . org-edit-indirect-mode))
```

or without `use-package` or Doom:

```elisp
(add-hook 'org-mode-hook #'org-edit-indirect-mode)
```